### PR TITLE
Fix finishing of push registration updating

### DIFF
--- a/urbanairship-sdk/src/main/java/com/urbanairship/push/ChannelJobHandler.java
+++ b/urbanairship-sdk/src/main/java/com/urbanairship/push/ChannelJobHandler.java
@@ -231,6 +231,8 @@ class ChannelJobHandler {
                 Logger.error("Push registration failed, will retry. Error: " + e.getMessage());
                 return Job.JOB_RETRY;
             }
+        } else {
+            isPushRegistering = false;
         }
 
         if (!isPushRegistering) {


### PR DESCRIPTION
Correct exit from push registering mode when registration token should not be updated.
Without this a tag list cannot be updated after application restarting until registration token will be changed or application data was cleaned.