### PR TITLE
Add proguard rule

### DIFF
--- a/urbanairship-sdk/consumer-proguard.txt
+++ b/urbanairship-sdk/consumer-proguard.txt
@@ -7,6 +7,7 @@
 -dontwarn com.amazon.device.messaging.**
 
 ## Autopilot
+-keep class com.urbanairship.Autopilot
 -keep public class * extends com.urbanairship.Autopilot
 
 ## Actions


### PR DESCRIPTION
Add rule for app that uses com.urbanairship.Autopilot directly (does not extend it).
