### PR TITLE
Fix for "Missing closing angular bracket" ProGuard exception

### DIFF
--- a/urbanairship-core/proguard-rules.pro
+++ b/urbanairship-core/proguard-rules.pro
@@ -10,15 +10,15 @@
 ## Push Providers
 -keep public class * extends com.urbanairship.push.PushProvider
 -keepclassmembernames class * extends com.urbanairship.push.PushProvider {
-  <public methods>;
-  <public fields>;
+  public <methods>;
+  public <fields>;
 }
 
 ## Airship Version Info
 -keep public class * extends com.urbanairship.AirshipVersionInfo
 -keepclassmembers class * extends com.urbanairship.AirshipVersionInfo {
-  <public methods>;
-  <public fields>;
+  public <methods>;
+  public <fields>;
 }
 
 ## Actions


### PR DESCRIPTION
This pull request fixes `java.lang.IllegalArgumentException: Missing closing angular bracket` exception, which is caused during the run of ProGuard on `urbanairship-core` module. ProGuard version 6.0.3