### PR TITLE
Don't require UA_DATA permission for use of SDK.

### DIFF
--- a/sample/src/androidTest/java/com/urbanairship/sample/SampleTest.java
+++ b/sample/src/androidTest/java/com/urbanairship/sample/SampleTest.java
@@ -769,7 +769,7 @@ public class SampleTest {
             filter.addAction("com.urbanairship.push.RECEIVED");
             filter.addCategory(UAirship.getPackageName());
 
-            UAirship.getApplicationContext().registerReceiver(this, filter, UAirship.getUrbanAirshipPermission(), new Handler(Looper.getMainLooper()));
+            UAirship.getApplicationContext().registerReceiver(this, filter, null, new Handler(Looper.getMainLooper()));
         }
 
         public void unregister() {

--- a/urbanairship-core/src/main/AndroidManifest.xml
+++ b/urbanairship-core/src/main/AndroidManifest.xml
@@ -9,8 +9,6 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
-    <permission android:name="${applicationId}.permission.UA_DATA" android:protectionLevel="signature" />
-    <uses-permission android:name="${applicationId}.permission.UA_DATA" />
     <application>
 
         <activity android:name="com.urbanairship.iam.html.HtmlActivity" />
@@ -97,9 +95,7 @@
 
         <provider
             android:name="com.urbanairship.UrbanAirshipProvider"
-            android:authorities="${applicationId}.urbanairship.provider"
-            android:permission="${applicationId}.permission.UA_DATA"
-            android:exported="true" />
+            android:authorities="${applicationId}.urbanairship.provider" />
 
     </application>
 </manifest>

--- a/urbanairship-core/src/main/java/com/urbanairship/AlarmOperationScheduler.java
+++ b/urbanairship-core/src/main/java/com/urbanairship/AlarmOperationScheduler.java
@@ -113,7 +113,7 @@ public class AlarmOperationScheduler implements OperationScheduler {
                     intentFilter.addAction(ACTION);
                     intentFilter.addCategory(toString());
 
-                    context.registerReceiver(receiver, intentFilter, UAirship.getUrbanAirshipPermission(), null);
+                    context.registerReceiver(receiver, intentFilter, null, null);
                     isRegistered = true;
                 }
             }

--- a/urbanairship-core/src/main/java/com/urbanairship/CoreReceiver.java
+++ b/urbanairship-core/src/main/java/com/urbanairship/CoreReceiver.java
@@ -113,7 +113,7 @@ public class CoreReceiver extends BroadcastReceiver {
                 .setPackage(UAirship.getPackageName())
                 .addCategory(UAirship.getPackageName());
 
-        context.sendOrderedBroadcast(openIntent, UAirship.getUrbanAirshipPermission());
+        context.sendOrderedBroadcast(openIntent, null);
     }
 
     /**
@@ -172,7 +172,7 @@ public class CoreReceiver extends BroadcastReceiver {
             openIntent.putExtra(AirshipReceiver.EXTRA_REMOTE_INPUT, remoteInput);
         }
 
-        context.sendOrderedBroadcast(openIntent, UAirship.getUrbanAirshipPermission());
+        context.sendOrderedBroadcast(openIntent, null);
     }
 
 
@@ -208,7 +208,7 @@ public class CoreReceiver extends BroadcastReceiver {
                 .setPackage(UAirship.getPackageName())
                 .addCategory(UAirship.getPackageName());
 
-        context.sendOrderedBroadcast(dismissIntent, UAirship.getUrbanAirshipPermission());
+        context.sendOrderedBroadcast(dismissIntent, null);
     }
 
     /**

--- a/urbanairship-core/src/main/java/com/urbanairship/UAirship.java
+++ b/urbanairship-core/src/main/java/com/urbanairship/UAirship.java
@@ -422,7 +422,7 @@ public class UAirship {
                     .setPackage(UAirship.getPackageName())
                     .addCategory(UAirship.getPackageName());
 
-            application.sendBroadcast(readyIntent, UAirship.getUrbanAirshipPermission());
+            application.sendBroadcast(readyIntent);
 
             // Notify any blocking shared
             airshipLock.notifyAll();
@@ -460,16 +460,6 @@ public class UAirship {
      */
     public static String getPackageName() {
         return getApplicationContext().getPackageName();
-    }
-
-    /**
-     * Returns the permission for sending Urban Airship push and registration broadcasts.
-     *
-     * @return The Urban Airship broadcast permission.
-     * @throws java.lang.IllegalStateException if takeOff has not been called.
-     */
-    public static String getUrbanAirshipPermission() {
-        return getApplicationContext().getPackageName() + ".permission.UA_DATA";
     }
 
     /**

--- a/urbanairship-core/src/main/java/com/urbanairship/push/IncomingPushRunnable.java
+++ b/urbanairship-core/src/main/java/com/urbanairship/push/IncomingPushRunnable.java
@@ -277,7 +277,7 @@ class IncomingPushRunnable implements Runnable {
             intent.putExtra(PushManager.EXTRA_NOTIFICATION_ID, notificationId.intValue());
         }
 
-        context.sendBroadcast(intent, UAirship.getUrbanAirshipPermission());
+        context.sendBroadcast(intent);
     }
 
     /**

--- a/urbanairship-core/src/main/java/com/urbanairship/push/PushManagerJobHandler.java
+++ b/urbanairship-core/src/main/java/com/urbanairship/push/PushManagerJobHandler.java
@@ -486,7 +486,7 @@ class PushManagerJobHandler {
             intent.putExtra(PushManager.EXTRA_ERROR, true);
         }
 
-        context.sendBroadcast(intent, UAirship.getUrbanAirshipPermission());
+        context.sendBroadcast(intent);
     }
 
 

--- a/urbanairship-core/src/main/java/com/urbanairship/util/ManifestUtils.java
+++ b/urbanairship-core/src/main/java/com/urbanairship/util/ManifestUtils.java
@@ -123,17 +123,14 @@ public class ManifestUtils {
                             Logger.error("Receiver " + info.name + " is exported. This might " +
                                     "allow outside applications to message the receiver. Make sure the intent is protected by a " +
                                     "permission or prevent the receiver from being exported.");
+                            throw new IllegalStateException("Receiver cannot be exported. Exporting the receiver allows other " +
+                                    "apps to send fake broadcasts to this app.");
                         }
                     }
                 } catch (ClassNotFoundException e) {
                     Logger.debug("ManifestUtils - Unable to find class: " + info.name, e);
                 }
             }
-        }
-
-        if (!ManifestUtils.isPermissionKnown(UAirship.getUrbanAirshipPermission())) {
-            throw new IllegalStateException("Missing required permission: " + UAirship.getUrbanAirshipPermission() + ". Verify the applicationId is set" +
-                    "in application's build.gradle file.");
         }
     }
 }

--- a/urbanairship-core/src/test/java/com/urbanairship/CoreReceiverTest.java
+++ b/urbanairship-core/src/test/java/com/urbanairship/CoreReceiverTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executor;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -86,7 +87,7 @@ public class CoreReceiverTest extends BaseTestCase {
                         UAirship.getPackageName().equals(other.getPackage()) &&
                         other.getCategories().contains(UAirship.getPackageName());
             }
-        }), eq(UAirship.getUrbanAirshipPermission()));
+        }), isNull(String.class));
     }
 
     /**
@@ -146,7 +147,7 @@ public class CoreReceiverTest extends BaseTestCase {
                         UAirship.getPackageName().equals(other.getPackage()) &&
                         other.getCategories().contains(UAirship.getPackageName());
             }
-        }), eq(UAirship.getUrbanAirshipPermission()));
+        }), isNull(String.class));
     }
 
     /**
@@ -208,6 +209,6 @@ public class CoreReceiverTest extends BaseTestCase {
                         UAirship.getPackageName().equals(other.getPackage()) &&
                         other.getCategories().contains(UAirship.getPackageName());
             }
-        }), eq(UAirship.getUrbanAirshipPermission()));
+        }), isNull(String.class));
     }
 }


### PR DESCRIPTION
- If the AirshipReceiver or extensions of it are never
  exported there is no need for a permission check. You
  are ensured that other apps cannot send fake data to
  your broadcast receiver.
- Remove permission and instead require the receivers
  cannot be exported.
- If the permission is guarding against the case where explicit
  broadcasts are not supported (pre IceCreamSandwich), the
  push notifications SDKs in use FCM / GCM already are only
  post IceCreamSandwich.
- Note: This change is a requirement for apps to integrate with Android
  Instant Apps. Instant Apps are not allowed to define their own permissions.