### PR TITLE
Support for Firebase Cloud Messaging version 18

### DIFF
--- a/documentation/migration/migration-guide-fcm.md
+++ b/documentation/migration/migration-guide-fcm.md
@@ -19,7 +19,7 @@ Migration Steps:
 
      // Urban Airship SDK - FCM
      implementation 'com.urbanairship.android:urbanairship-fcm:9.1.0'
-     implementation 'com.google.firebase:firebase-messaging:15.0.0'
+     implementation 'com.google.firebase:firebase-messaging:17.1.0'
 
      // Urban Airship SDK - ADM (Optional - if you support ADM)
      implementation 'com.urbanairship.android:urbanairship-adm:9.1.0'
@@ -27,18 +27,9 @@ Migration Steps:
 ```
 
 
-- If your application uses its own `FirebaseMessagingService`, `FirebaseInstanceIDService`, or another
+- If your application uses its own `FirebaseMessagingService` or another
 provider that uses FCM, you will need to forward token refresh and message received calls to the
 Urban Airship SDK:
-
-```
-// FirebaseInstanceIdService:
-
-public void onTokenRefresh() {
-   // Notify Urban Airship that the token is refreshed.
-   AirshipFirebaseInstanceIdService.processTokenRefresh(getContext());
-}
-```
 
 ```
 // FirebaseMessagingService:
@@ -46,5 +37,11 @@ public void onTokenRefresh() {
 @Override
 public void onMessageReceived(RemoteMessage remoteMessage) {
    AirshipFirebaseMessagingService.processMessageSync(getContext(), remoteMessage);
+}
+
+@Override
+public void onNewToken(String token) {
+   // Notify Urban Airship that the token is refreshed.
+   AirshipFirebaseMessagingService.processTokenRefresh(getContext());
 }
 ```

--- a/urbanairship-fcm/src/main/AndroidManifest.xml
+++ b/urbanairship-fcm/src/main/AndroidManifest.xml
@@ -13,13 +13,5 @@
             </intent-filter>
         </service>
 
-        <service
-            android:name="com.urbanairship.push.fcm.AirshipFirebaseInstanceIdService">
-            <intent-filter android:priority="-1" >
-                <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
-            </intent-filter>
-        </service>
-
-
     </application>
 </manifest>

--- a/urbanairship-fcm/src/main/java/com/urbanairship/push/fcm/AirshipFirebaseInstanceIdService.java
+++ b/urbanairship-fcm/src/main/java/com/urbanairship/push/fcm/AirshipFirebaseInstanceIdService.java
@@ -4,24 +4,23 @@ package com.urbanairship.push.fcm;
 
 import android.content.Context;
 
-import com.google.firebase.iid.FirebaseInstanceIdService;
 import com.urbanairship.push.PushProviderBridge;
 
 /**
  * Urban Airship FirebaseInstanceIdService.
+ *
+ * @deprecated Use AirshipFirebaseMessagingService instead
  */
-public class AirshipFirebaseInstanceIdService extends FirebaseInstanceIdService {
-    @Override
-    public void onTokenRefresh() {
-        super.onTokenRefresh();
-        processTokenRefresh(getApplicationContext());
-    }
-
+@Deprecated
+public class AirshipFirebaseInstanceIdService {
     /**
      * Called to handle token refresh.
      *
+     * @deprecated Use AirshipFirebaseMessagingService.processTokenRefresh instead
+     *
      * @param context The application context.
      */
+    @Deprecated
     public static void processTokenRefresh(Context context) {
         PushProviderBridge.requestRegistrationUpdate(context);
     }

--- a/urbanairship-fcm/src/main/java/com/urbanairship/push/fcm/AirshipFirebaseMessagingService.java
+++ b/urbanairship-fcm/src/main/java/com/urbanairship/push/fcm/AirshipFirebaseMessagingService.java
@@ -25,6 +25,13 @@ public class AirshipFirebaseMessagingService extends FirebaseMessagingService {
         processMessageSync(getApplicationContext(), message);
     }
 
+    @Override
+    public void onNewToken(String token) {
+        super.onNewToken(token);
+
+        processTokenRefresh(getApplicationContext());
+    }
+
     /**
      * Called to handle {@link #onMessageReceived(RemoteMessage)}. The task should be finished
      * before `onMessageReceived(RemoteMessage message)` is complete. Wait for the message to be complete
@@ -56,5 +63,14 @@ public class AirshipFirebaseMessagingService extends FirebaseMessagingService {
     public static void processMessageSync(Context context, RemoteMessage message) {
         PushProviderBridge.processPush(FcmPushProvider.class, new PushMessage(message.getData()))
                           .executeSync(context);
+    }
+
+    /**
+     * Called to handle token refresh.
+     *
+     * @param context The application context.
+     */
+    public static void processTokenRefresh(Context context) {
+        PushProviderBridge.requestRegistrationUpdate(context);
     }
 }


### PR DESCRIPTION
### What do these changes do?

Removes usage of previously deprecated `FirebaseInstanceIdService` which is removed in Firebase Cloud Messaging version 18

`FirebaseMessagingService` method `onNewToken` should be used for token refresh instead.

https://firebase.google.com/support/release-notes/android

### Why are these changes necessary?

Usage of `FirebaseInstanceIdService` makes it impossible to use Firebase Cloud Messaging version 18 in apps consuming this SDK

### How did you verify these changes?

Android project using Firebase Cloud Messaging version 18 builds using this change

### Anything else a reviewer should know?

I've marked `AirshipFirebaseInstanceIdService` class and its `processTokenRefresh` method as deprecated, referring to `AirshipFirebaseMessagingService` instead. The alternative would be to remove `AirshipFirebaseInstanceIdService` entirely but that would be a breaking change.

Firebase Cloud Messaging version 17.1.0 introduces the new `onNewToken` so that will be the minimum required version.

As long as users of this SDK is on FCM 17.1.0 or above it should just keep working.