### PR TITLE
Accengage notification icon fallback to airship config

### DIFF
--- a/urbanairship-accengage/src/main/java/com/urbanairship/accengage/Accengage.java
+++ b/urbanairship-accengage/src/main/java/com/urbanairship/accengage/Accengage.java
@@ -7,6 +7,7 @@ import android.content.SharedPreferences;
 import android.text.TextUtils;
 
 import com.urbanairship.AirshipComponent;
+import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.Logger;
 import com.urbanairship.PreferenceDataStore;
 import com.urbanairship.UAirship;
@@ -35,6 +36,7 @@ import androidx.annotation.VisibleForTesting;
  */
 public class Accengage extends AirshipComponent {
 
+    private final AirshipConfigOptions configOptions;
     private final AirshipChannel airshipChannel;
     private final PushManager pushManager;
     private final Analytics analytics;
@@ -116,10 +118,10 @@ public class Accengage extends AirshipComponent {
      * @param pushManager The push manager.
      * @param analytics The analytics instance.
      */
-    Accengage(@NonNull Context context, @NonNull PreferenceDataStore dataStore,
+    Accengage(@NonNull Context context, @NonNull AirshipConfigOptions configOptions, @NonNull PreferenceDataStore dataStore,
               @NonNull AirshipChannel airshipChannel, @NonNull PushManager pushManager,
               @NonNull Analytics analytics) {
-        this(context, dataStore, airshipChannel, pushManager, analytics, new AccengageSettingsLoader());
+        this(context, configOptions, dataStore, airshipChannel, pushManager, analytics, new AccengageSettingsLoader());
     }
 
     /**
@@ -133,16 +135,17 @@ public class Accengage extends AirshipComponent {
      * @param settingsLoader The settings loader.
      */
     @VisibleForTesting
-    Accengage(@NonNull Context context, @NonNull PreferenceDataStore dataStore,
+    Accengage(@NonNull Context context, @NonNull AirshipConfigOptions configOptions, @NonNull PreferenceDataStore dataStore,
               @NonNull AirshipChannel airshipChannel, @NonNull PushManager pushManager,
               @NonNull Analytics analytics, @NonNull AccengageSettingsLoader settingsLoader) {
         super(context, dataStore);
 
+        this.configOptions = configOptions;
         this.airshipChannel = airshipChannel;
         this.pushManager = pushManager;
         this.analytics = analytics;
         this.settingsLoader = settingsLoader;
-        this.notificationProvider = new AccengageNotificationProvider();
+        this.notificationProvider = new AccengageNotificationProvider(configOptions);
     }
 
     @Override
@@ -259,7 +262,7 @@ public class Accengage extends AirshipComponent {
             return;
         }
 
-        AccengageMessage message = AccengageMessage.fromAirshipPushMessage(notificationInfo.getMessage());
+        AccengageMessage message = AccengageMessage.fromAirshipPushMessage(notificationInfo.getMessage(), configOptions);
 
         AccengagePushButton button = null;
         if (actionButtonInfo != null) {

--- a/urbanairship-accengage/src/main/java/com/urbanairship/accengage/AccengageModuleFactoryImpl.java
+++ b/urbanairship-accengage/src/main/java/com/urbanairship/accengage/AccengageModuleFactoryImpl.java
@@ -4,6 +4,7 @@ package com.urbanairship.accengage;
 
 import android.content.Context;
 
+import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.PreferenceDataStore;
 import com.urbanairship.analytics.Analytics;
 import com.urbanairship.channel.AirshipChannel;
@@ -26,11 +27,11 @@ public class AccengageModuleFactoryImpl implements AccengageModuleFactory {
 
     @NonNull
     @Override
-    public AccengageModule build(@NonNull Context context, @NonNull PreferenceDataStore dataStore,
+    public AccengageModule build(@NonNull Context context, @NonNull AirshipConfigOptions configOptions, @NonNull PreferenceDataStore dataStore,
                                  @NonNull AirshipChannel airshipChannel, @NonNull PushManager pushManager,
                                  @NonNull Analytics analytics) {
 
-        final Accengage accengage = new Accengage(context, dataStore, airshipChannel, pushManager, analytics);
+        final Accengage accengage = new Accengage(context, configOptions, dataStore, airshipChannel, pushManager, analytics);
         return new AccengageModule(accengage, new AccengageNotificationHandler() {
             @NonNull
             @Override

--- a/urbanairship-accengage/src/main/java/com/urbanairship/accengage/notifications/AccengageNotificationProvider.java
+++ b/urbanairship-accengage/src/main/java/com/urbanairship/accengage/notifications/AccengageNotificationProvider.java
@@ -5,9 +5,11 @@ package com.urbanairship.accengage.notifications;
 import android.app.Notification;
 import android.content.Context;
 
+import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.Logger;
 import com.urbanairship.accengage.AccengageMessage;
 import com.urbanairship.app.GlobalActivityMonitor;
+import com.urbanairship.push.PushManager;
 import com.urbanairship.push.PushMessage;
 import com.urbanairship.push.notifications.NotificationArguments;
 import com.urbanairship.push.notifications.NotificationChannelUtils;
@@ -21,11 +23,16 @@ import androidx.core.app.NotificationCompat;
  * Accengage notification provider.
  */
 public class AccengageNotificationProvider implements NotificationProvider {
+    private final AirshipConfigOptions configOptions;
+
+    public AccengageNotificationProvider(AirshipConfigOptions configOptions) {
+        this.configOptions = configOptions;
+    }
 
     @NonNull
     @Override
     public NotificationArguments onCreateNotificationArguments(@NonNull Context context, @NonNull PushMessage message) {
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(message);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(message, configOptions);
 
         String requestedChannelId = accengageMessage.getAccengageChannel();
         String activeChannelId = NotificationChannelUtils.getActiveChannel(requestedChannelId, DEFAULT_NOTIFICATION_CHANNEL);
@@ -39,7 +46,7 @@ public class AccengageNotificationProvider implements NotificationProvider {
     @NonNull
     @Override
     public NotificationResult onCreateNotification(@NonNull Context context, @NonNull NotificationArguments arguments) {
-        AccengageMessage message = AccengageMessage.fromAirshipPushMessage(arguments.getMessage());
+        AccengageMessage message = AccengageMessage.fromAirshipPushMessage(arguments.getMessage(), configOptions);
 
         if (!message.getAccengageForeground() && GlobalActivityMonitor.shared(context).isAppForegrounded()) {
             Logger.debug("Received Accengage Push message but application was in foreground, skip it...");

--- a/urbanairship-accengage/src/test/java/com/urbanairship/accengage/AccengageModuleImplTest.java
+++ b/urbanairship-accengage/src/test/java/com/urbanairship/accengage/AccengageModuleImplTest.java
@@ -2,6 +2,7 @@ package com.urbanairship.accengage;
 
 import android.app.Application;
 
+import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.PreferenceDataStore;
 import com.urbanairship.accengage.notifications.AccengageNotificationProvider;
 import com.urbanairship.analytics.Analytics;
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.mock;
 public class AccengageModuleImplTest {
 
     private AccengageModule accengageModuleLoader;
+    private AirshipConfigOptions mockConfig;
 
     @Before
     public void setup() {
@@ -36,7 +38,8 @@ public class AccengageModuleImplTest {
         PushManager mockPush = mock(PushManager.class);
         PreferenceDataStore preferenceDataStore = new PreferenceDataStore(application);
 
-        accengageModuleLoader = new AccengageModuleFactoryImpl().build(application, preferenceDataStore, mockChannel, mockPush, mockAnalytics);
+        mockConfig = mock(AirshipConfigOptions.class);
+        accengageModuleLoader = new AccengageModuleFactoryImpl().build(application, mockConfig, preferenceDataStore, mockChannel, mockPush, mockAnalytics);
     }
 
     @Test
@@ -48,7 +51,7 @@ public class AccengageModuleImplTest {
 
         assertEquals(accengage.getNotificationProvider(), accengageModuleLoader.getAccengageNotificationHandler().getNotificationProvider());
 
-        NotificationProvider notificationProvider = new AccengageNotificationProvider();
+        NotificationProvider notificationProvider = new AccengageNotificationProvider(mockConfig);
 
         accengage.setNotificationProvider(notificationProvider);
 

--- a/urbanairship-accengage/src/test/java/com/urbanairship/accengage/AccengageTest.java
+++ b/urbanairship-accengage/src/test/java/com/urbanairship/accengage/AccengageTest.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.PreferenceDataStore;
 import com.urbanairship.UAirship;
 import com.urbanairship.accengage.common.persistence.AccengageSettingsLoader;
@@ -34,6 +35,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 @RunWith(AndroidJUnit4.class)
 public class AccengageTest {
 
+    private AirshipConfigOptions mockConfig;
     private AirshipChannel mockChannel;
     private PushManager mockPush;
     private Analytics mockAnalytics;
@@ -48,6 +50,7 @@ public class AccengageTest {
         Application application = ApplicationProvider.getApplicationContext();
         PreferenceDataStore preferenceDataStore = new PreferenceDataStore(application);
 
+        mockConfig = mock(AirshipConfigOptions.class);
         mockChannel = mock(AirshipChannel.class);
         mockAnalytics = mock(Analytics.class);
         mockPush = mock(PushManager.class);
@@ -63,7 +66,7 @@ public class AccengageTest {
             }
         };
 
-        accengage = new Accengage(application, preferenceDataStore, mockChannel, mockPush, mockAnalytics, settingsLoader);
+        accengage = new Accengage(application, mockConfig, preferenceDataStore, mockChannel, mockPush, mockAnalytics, settingsLoader);
     }
 
     /**

--- a/urbanairship-accengage/src/test/java/com/urbanairship/accengage/notifications/AccengageMessageTest.java
+++ b/urbanairship-accengage/src/test/java/com/urbanairship/accengage/notifications/AccengageMessageTest.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.graphics.Color;
 import android.os.Bundle;
 
+import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.accengage.AccengageMessage;
 import com.urbanairship.push.PushMessage;
 
@@ -12,6 +13,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -21,16 +23,24 @@ import androidx.core.app.NotificationCompat;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static org.mockito.Mockito.mock;
+
 @Config(sdk = 28)
 @RunWith(AndroidJUnit4.class)
 public class AccengageMessageTest {
+    private AirshipConfigOptions defaultConfig;
 
+    @Before
+    public void setup() {
+        defaultConfig = AirshipConfigOptions.newBuilder().build();
+    }
+    
     @Test(expected = IllegalArgumentException.class)
     public void testFromAirshipPushMessage() {
         Bundle extras = new Bundle();
         PushMessage pushMessage = new PushMessage(extras);
 
-        AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
     }
 
     @Test
@@ -40,7 +50,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push title should be testTitle", "testTitle",
                 accengageMessage.getAccengageTitle());
@@ -53,7 +63,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push content should be testContent", "testContent",
                 accengageMessage.getAccengageContent());
@@ -66,7 +76,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push System ID should be 1002", 1002,
                 accengageMessage.getAccengageSystemId());
@@ -79,7 +89,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push Priority should be 3", 3,
                 accengageMessage.getAccengagePriority());
@@ -92,7 +102,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push Category should be Event", NotificationCompat.CATEGORY_EVENT,
                 accengageMessage.getAccengageCategory());
@@ -105,7 +115,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push Color should be #FF0000", Color.parseColor("#FF0000"),
                 accengageMessage.getAccengageAccentColor());
@@ -116,12 +126,41 @@ public class AccengageMessageTest {
         Application application = ApplicationProvider.getApplicationContext();
         Context context = Mockito.spy(application);
         Bundle extras = new Bundle();
+        extras.putInt("a4ssmalliconname", 1);
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
-        Assert.assertEquals("The Push Icon Int should be 0", 0,
+        Assert.assertEquals("The Push Icon Int should be 2", 1,
+                accengageMessage.getAccengageSmallIcon(context));
+    }
+    @Test
+    public void testGetFallbackAccentColor() {
+        Bundle extras = new Bundle();
+        AirshipConfigOptions airshipConfigOptions = AirshipConfigOptions.newBuilder().setNotificationAccentColor(Color.GREEN).build();
+
+        extras.putString("a4scontent", "accengage");
+
+        PushMessage pushMessage = new PushMessage(extras);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, airshipConfigOptions);
+
+        Assert.assertEquals("The Push Color should fallback to #FF00FF00", Color.GREEN,
+                accengageMessage.getAccengageAccentColor());
+    }
+
+    @Test
+    public void testGetFallbackSmallIcon() {
+        Application application = ApplicationProvider.getApplicationContext();
+        Context context = Mockito.spy(application);
+        Bundle extras = new Bundle();
+        extras.putString("a4scontent", "accengage");
+        AirshipConfigOptions airshipConfigOptions = AirshipConfigOptions.newBuilder().setNotificationIcon(2).build();
+
+        PushMessage pushMessage = new PushMessage(extras);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, airshipConfigOptions);
+
+        Assert.assertEquals("The Push Icon Int should fallback to 2", 2,
                 accengageMessage.getAccengageSmallIcon(context));
     }
 
@@ -132,7 +171,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push Notification sound should be testCustomSound",
                 "testCustomSound", accengageMessage.getAccengageNotificationSound());
@@ -145,7 +184,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push Notification group should be testGroup",
                 "testGroup", accengageMessage.getAccengageGroup());
@@ -158,7 +197,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertTrue("The Push Notification group should be true",
                 accengageMessage.getAccengageGroupSummary());
@@ -171,7 +210,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push Content info should be testContentInfo",
                 "testContentInfo", accengageMessage.getAccengageContentInfo());
@@ -184,7 +223,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push Subtext should be testSubText",
                 "testSubText", accengageMessage.getAccengageSubtext());
@@ -197,7 +236,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push Summary Text should be testSummaryText",
                 "testSummaryText", accengageMessage.getAccengageSummaryText());
@@ -210,7 +249,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertTrue("The Push Multiple lines should be true",
                 accengageMessage.isAccengageMultipleLines());
@@ -223,7 +262,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push Big Template should be testBigTemplate",
                 "testBigTemplate", accengageMessage.getAccengageBigTemplate());
@@ -236,7 +275,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push Template should be testTemplate",
                 "testTemplate", accengageMessage.getAccengageTemplate());
@@ -249,7 +288,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push BigContent should be testBigContent",
                 "testBigContent", accengageMessage.getAccengageBigContent());
@@ -262,7 +301,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push BigPictureUrl should be testBigPictureUrl",
                 "testBigPictureUrl", accengageMessage.getAccengageBigPictureUrl());
@@ -275,7 +314,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push channel should be testChannel",
                 "testChannel", accengageMessage.getAccengageChannel());
@@ -288,7 +327,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push icon should be testIcon",
                 "testIcon", accengageMessage.getAccengageLargeIcon());
@@ -301,7 +340,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertTrue("The Push Foreground property should be true",
                 accengageMessage.getAccengageForeground());
@@ -314,7 +353,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push action should be testAction",
                 "testAction", accengageMessage.getAccengageAction());
@@ -327,7 +366,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertTrue("The Push open with browser should be true",
                 accengageMessage.getAccengageOpenWithBrowser());
@@ -340,7 +379,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertTrue("The Push property isDecorated should be true",
                 accengageMessage.getAccengageIsDecorated());
@@ -353,7 +392,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push app name should be testAppName",
                 "testAppName", accengageMessage.getAccengageAppName());
@@ -366,7 +405,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push header text name should be testHeaderText",
                 "testHeaderText", accengageMessage.getAccengageHeaderText());
@@ -379,7 +418,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push customKey's value should be customValue",
                 "testCustomValue", accengageMessage.getExtra("testCustomKey"));
@@ -392,7 +431,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push customKey's value should be customValue",
                 "testDefaultValue", accengageMessage.getExtra("fakeKey", "testDefaultValue"));
@@ -405,7 +444,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertEquals("The Push url value should be testAccUrl",
                 "testAccUrl", accengageMessage.getAccengageUrl());
@@ -441,7 +480,7 @@ public class AccengageMessageTest {
         extras.putString("a4scontent", "accengage");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage accengageMessage = AccengageMessage.fromAirshipPushMessage(pushMessage, defaultConfig);
 
         Assert.assertTrue(accengageMessage.getButtons().get(0).getOpenApp());
         Assert.assertEquals("com_ad4screen_sdk_notification_icon_yes",

--- a/urbanairship-accengage/src/test/java/com/urbanairship/accengage/notifications/AccengageMessageTest.java
+++ b/urbanairship-accengage/src/test/java/com/urbanairship/accengage/notifications/AccengageMessageTest.java
@@ -34,7 +34,7 @@ public class AccengageMessageTest {
     public void setup() {
         defaultConfig = AirshipConfigOptions.newBuilder().build();
     }
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void testFromAirshipPushMessage() {
         Bundle extras = new Bundle();

--- a/urbanairship-accengage/src/test/java/com/urbanairship/accengage/notifications/AccengageNotificationExtenderTest.java
+++ b/urbanairship-accengage/src/test/java/com/urbanairship/accengage/notifications/AccengageNotificationExtenderTest.java
@@ -6,11 +6,13 @@ import android.content.Context;
 import android.graphics.Color;
 import android.os.Bundle;
 
+import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.accengage.AccengageMessage;
 import com.urbanairship.push.PushMessage;
 import com.urbanairship.push.notifications.NotificationArguments;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -20,10 +22,17 @@ import androidx.core.app.NotificationCompat;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static org.mockito.Mockito.mock;
+
 @Config(sdk = 28)
 @RunWith(AndroidJUnit4.class)
 public class AccengageNotificationExtenderTest {
+    private AirshipConfigOptions mockConfig;
 
+    @Before
+    public void setup() {
+        mockConfig = mock(AirshipConfigOptions.class);
+    }
     @Test
     public void testExtend() {
         Application application = ApplicationProvider.getApplicationContext();
@@ -42,7 +51,7 @@ public class AccengageNotificationExtenderTest {
         extras.putBoolean("a4smultiplelines", true);
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage message = AccengageMessage.fromAirshipPushMessage(pushMessage);
+        AccengageMessage message = AccengageMessage.fromAirshipPushMessage(pushMessage, mockConfig);
 
         // Setup the NotificationsExtender
         NotificationArguments.Builder naBuilder = NotificationArguments.newBuilder(pushMessage);

--- a/urbanairship-accengage/src/test/java/com/urbanairship/accengage/notifications/AccengageNotificationProviderTest.java
+++ b/urbanairship-accengage/src/test/java/com/urbanairship/accengage/notifications/AccengageNotificationProviderTest.java
@@ -5,12 +5,14 @@ import android.app.Notification;
 import android.content.Context;
 import android.os.Bundle;
 
+import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.accengage.AccengageMessage;
 import com.urbanairship.push.PushMessage;
 import com.urbanairship.push.notifications.NotificationArguments;
 import com.urbanairship.push.notifications.NotificationResult;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -19,9 +21,17 @@ import org.robolectric.annotation.Config;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static org.mockito.Mockito.mock;
+
 @Config(sdk = 28)
 @RunWith(AndroidJUnit4.class)
 public class AccengageNotificationProviderTest {
+    private AirshipConfigOptions mockConfig;
+
+    @Before
+    public void setup() {
+        mockConfig = mock(AirshipConfigOptions.class);
+    }
 
     @Test
     public void testOnCreateNotificationArguments() {
@@ -34,9 +44,8 @@ public class AccengageNotificationProviderTest {
         extras.putString("a4stitle", "title test");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage message = AccengageMessage.fromAirshipPushMessage(pushMessage);
 
-        AccengageNotificationProvider accengageNotificationProvider = new AccengageNotificationProvider();
+        AccengageNotificationProvider accengageNotificationProvider = new AccengageNotificationProvider(mockConfig);
 
         NotificationArguments arguments = accengageNotificationProvider.onCreateNotificationArguments(context, pushMessage);
 
@@ -56,9 +65,8 @@ public class AccengageNotificationProviderTest {
         extras.putString("a4sforeground", "true");
 
         PushMessage pushMessage = new PushMessage(extras);
-        AccengageMessage message = AccengageMessage.fromAirshipPushMessage(pushMessage);
 
-        AccengageNotificationProvider accengageNotificationProvider = new AccengageNotificationProvider();
+        AccengageNotificationProvider accengageNotificationProvider = new AccengageNotificationProvider(mockConfig);
 
         NotificationArguments arguments = accengageNotificationProvider.onCreateNotificationArguments(context, pushMessage);
         NotificationResult result = accengageNotificationProvider.onCreateNotification(context, arguments);

--- a/urbanairship-core/src/main/java/com/urbanairship/UAirship.java
+++ b/urbanairship-core/src/main/java/com/urbanairship/UAirship.java
@@ -760,7 +760,7 @@ public class UAirship {
         processModule(debugModule);
 
         // Accengage
-        AccengageModule accengageModule = Modules.accengage(application, preferenceDataStore, channel, pushManager, analytics);
+        AccengageModule accengageModule = Modules.accengage(application, airshipConfigOptions, preferenceDataStore, channel, pushManager, analytics);
         processModule(accengageModule);
         this.accengageNotificationHandler = accengageModule == null ? null : accengageModule.getAccengageNotificationHandler();
 

--- a/urbanairship-core/src/main/java/com/urbanairship/modules/Modules.java
+++ b/urbanairship-core/src/main/java/com/urbanairship/modules/Modules.java
@@ -4,6 +4,7 @@ package com.urbanairship.modules;
 
 import android.content.Context;
 
+import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.AirshipVersionInfo;
 import com.urbanairship.Logger;
 import com.urbanairship.PreferenceDataStore;
@@ -44,6 +45,7 @@ public class Modules {
 
     @Nullable
     public static AccengageModule accengage(@NonNull Context context,
+                                            @NonNull AirshipConfigOptions configOptions,
                                             @NonNull PreferenceDataStore preferenceDataStore,
                                             @NonNull AirshipChannel channel,
                                             @NonNull PushManager pushManager,
@@ -51,7 +53,7 @@ public class Modules {
         try {
             AccengageModuleFactory moduleFactory = createFactory(ACCENGAGE_MODULE_FACTORY, AccengageModuleFactory.class);
             if (moduleFactory != null) {
-                return moduleFactory.build(context, preferenceDataStore, channel, pushManager, analytics);
+                return moduleFactory.build(context, configOptions, preferenceDataStore, channel, pushManager, analytics);
             }
         } catch (Exception e) {
             Logger.error(e, "Failed to build Accengage module");

--- a/urbanairship-core/src/main/java/com/urbanairship/modules/accengage/AccengageModuleFactory.java
+++ b/urbanairship-core/src/main/java/com/urbanairship/modules/accengage/AccengageModuleFactory.java
@@ -4,6 +4,7 @@ package com.urbanairship.modules.accengage;
 
 import android.content.Context;
 
+import com.urbanairship.AirshipConfigOptions;
 import com.urbanairship.AirshipVersionInfo;
 import com.urbanairship.PreferenceDataStore;
 import com.urbanairship.analytics.Analytics;
@@ -23,6 +24,7 @@ public interface AccengageModuleFactory extends AirshipVersionInfo {
 
     @NonNull
     AccengageModule build(@NonNull Context context,
+                          @NonNull AirshipConfigOptions configOptions,
                           @NonNull PreferenceDataStore dataStore,
                           @NonNull AirshipChannel airshipChannel,
                           @NonNull PushManager manager,


### PR DESCRIPTION
We recently migrated several apps from accengage to airship, which works fine, except that we discovered that whenever we send notifications from accengage dashboard the notification icon is missing. This can be fixed by sending notifications only via airship dashboard or add the custom parameter a4ssmalliconname with value of the notification icon. But since the default behavior is simply not defining any custom parameter which should actually result in correctly displayed notifications, i suggest to fall back to the airship configuration in terms of notification icon and color in case those properties are not provided within the pushmessage