### PR TITLE
Remove check for user notifications enabled when checking opt in status

### DIFF
--- a/urbanairship-core/src/main/java/com/urbanairship/push/PushManager.java
+++ b/urbanairship-core/src/main/java/com/urbanairship/push/PushManager.java
@@ -699,7 +699,7 @@ public class PushManager extends AirshipComponent {
      * @return {@code true} if notifications are opted in, otherwise {@code false}.
      */
     public boolean areNotificationsOptedIn() {
-        return getUserNotificationsEnabled() && notificationManagerCompat.areNotificationsEnabled();
+        return notificationManagerCompat.areNotificationsEnabled();
     }
 
     /**


### PR DESCRIPTION
### What do these changes do?
Removes the check for user notifications enabled when checking opt in status

### Why are these changes necessary?
Discrepancy between Android and iOS library. iOS returns system status without this check. Removing it gives us consistent behavior of `isUserNotificationsEnabled` and `IsUserNotificationsOptedIn` across both platforms.

### Anything else a reviewer should know?
Resolves https://github.com/urbanairship/react-native-module/issues/349 and https://github.com/urbanairship/android-library/issues/189
