### PR TITLE
InApp Button stroke width is customizable

### DIFF
--- a/urbanairship-automation/src/main/java/com/urbanairship/iam/view/InAppViewUtils.java
+++ b/urbanairship-automation/src/main/java/com/urbanairship/iam/view/InAppViewUtils.java
@@ -26,6 +26,7 @@ import android.widget.TextView;
 
 import com.urbanairship.Fonts;
 import com.urbanairship.UALog;
+import com.urbanairship.automation.R;
 import com.urbanairship.iam.ButtonInfo;
 import com.urbanairship.iam.MediaInfo;
 import com.urbanairship.iam.TextInfo;
@@ -57,7 +58,6 @@ import androidx.core.view.ViewCompat;
 public class InAppViewUtils {
 
     private static final float PRESSED_ALPHA_PERCENT = .2f;
-    private static final int DEFAULT_STROKE_WIDTH_DPS = 2;
     private static final float DEFAULT_BORDER_RADIUS = 0;
 
     /**
@@ -66,8 +66,9 @@ public class InAppViewUtils {
      * @param button The button view.
      * @param buttonInfo The button info.
      * @param borderRadiusFlag The border radius flag.
+     * @param strokeWidthInDps The stroke width in dps.
      */
-    public static void applyButtonInfo(@NonNull Button button, @NonNull ButtonInfo buttonInfo, @BorderRadius.BorderRadiusFlag int borderRadiusFlag) {
+    public static void applyButtonInfo(@NonNull Button button, @NonNull ButtonInfo buttonInfo, @BorderRadius.BorderRadiusFlag int borderRadiusFlag, int strokeWidthInDps) {
         applyButtonTextInfo(button, buttonInfo.getLabel());
 
         int textColor = buttonInfo.getLabel().getColor() == null ? button.getCurrentTextColor() : buttonInfo.getLabel().getColor();
@@ -82,10 +83,22 @@ public class InAppViewUtils {
                 .setBorderRadius(borderRadius, borderRadiusFlag)
                 .setPressedColor(pressedColor)
                 .setStrokeColor(strokeColor)
-                .setStrokeWidth(DEFAULT_STROKE_WIDTH_DPS)
+                .setStrokeWidth(strokeWidthInDps)
                 .build();
 
         ViewCompat.setBackground(button, background);
+    }
+
+    /**
+     * Applies button info to a button.
+     *
+     * @param button The button view.
+     * @param buttonInfo The button info.
+     * @param borderRadiusFlag The border radius flag.
+     */
+    public static void applyButtonInfo(@NonNull Button button, @NonNull ButtonInfo buttonInfo, @BorderRadius.BorderRadiusFlag int borderRadiusFlag) {
+        int strokeWidth = button.getContext().getResources().getInteger(R.integer.ua_iam_button_stroke_width_dps);
+        applyButtonInfo(button, buttonInfo, borderRadiusFlag, strokeWidth);
     }
 
     /**

--- a/urbanairship-automation/src/main/res/values/config_iam.xml
+++ b/urbanairship-automation/src/main/res/values/config_iam.xml
@@ -5,4 +5,6 @@
 
     <bool name="ua_iam_modal_allow_fullscreen_display">true</bool>
     <bool name="ua_iam_html_allow_fullscreen_display">true</bool>
+
+    <integer name="ua_iam_button_stroke_width_dps">2</integer>
 </resources>


### PR DESCRIPTION

### What do these changes do?
This PR adds the functionality to edit the stroke/border width for the InApp buttons. 

Apps that want to override the stroke width in InApp Message buttons, can override the default value (2dp) by adding this to their resources (`res/{values|dimens|any_name}.xml`) file: 
```
<resources>
	<integer name="ua_iam_button_stroke_width_dps">1</integer>
</resources>
````

### Why are these changes necessary?
These changes will add flexibility to InApp Messages to get in line with the app's design. 

### How did you verify these changes?
#### Verification Screenshots:
<table>
<tr>
 <td> Before
 <td> After (default)
 <td> After (1dp)
<tr>
 <td> <img src="https://github.com/urbanairship/android-library/assets/112569658/9bb5f494-329b-44b9-b909-1349b12c2a59" width=250/>
 <td> <img src="https://github.com/urbanairship/android-library/assets/112569658/1b2cad6e-7b08-40b3-a7d3-72817acc956b" width=250/>
 <td> <img src="https://github.com/urbanairship/android-library/assets/112569658/861b5530-dec1-425e-be78-2a375297c96a" width=250/>
</table>

To override the stroke width I added `<integer name="ua_iam_button_stroke_width_dps">1</integer>` in 
`~/sample/src/main/res/values/dimens.xml`

