### PR TITLE
Define oldToken as nullable in PushManager.onTokenChanged

### DIFF
--- a/urbanairship-core/src/main/java/com/urbanairship/push/PushManager.kt
+++ b/urbanairship-core/src/main/java/com/urbanairship/push/PushManager.kt
@@ -1054,7 +1054,7 @@ public open class PushManager @VisibleForTesting internal constructor(
     public fun onTokenChanged(pushProviderClass: Class<out PushProvider?>?, token: String?) {
         if (privacyManager.isEnabled(PrivacyManager.Feature.PUSH) && pushProvider != null) {
             if (pushProviderClass != null && pushProvider!!.javaClass == pushProviderClass) {
-                val oldToken: String = preferenceDataStore.getString(PUSH_TOKEN_KEY, null)
+                val oldToken: String? = preferenceDataStore.getString(PUSH_TOKEN_KEY, null)
                 if (token != null && !UAStringUtil.equals(token, oldToken)) {
                     clearPushToken()
                 }


### PR DESCRIPTION
<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
Define `oldToken` as nullable in` PushManager.onTokenChanged`. 
`PushManager` was migrated from JAVA to Kotlin, and the variable type was defined incorrectly. 
The default value of the string, when the resource doesn't exist is set as `null`.

### Why are these changes necessary?
We haven't defined a PUSH_TOKEN_KEY in our app. 
We have a trending crash in Crashlytics,

```
  Fatal Exception: java.lang.NullPointerException: getString(...) must not be null
at com.urbanairship.push.PushManager.onTokenChanged(PushManager.java:1057)
```
